### PR TITLE
Remove infinites values on request

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -148,11 +148,11 @@ def get_data(pair, strategy):
         "pair": pair,
         "strategy": strategy,
         "data": data if details == "True" else [],
-        "result": (
-            result.indicators if details == "True" else [],
-            result.positions,
-            result.current_positions
-        ),
+        #"result": (
+        #    result.indicators if details == "True" else [],
+        #    result.positions,
+        #    result.current_positions
+        #),
         "stats": {
             "drawdown": get_drawdowns_stats(result),
             "positions": get_position_stats(result)

--- a/api/api.py
+++ b/api/api.py
@@ -148,11 +148,11 @@ def get_data(pair, strategy):
         "pair": pair,
         "strategy": strategy,
         "data": data if details == "True" else [],
-        #"result": (
-        #    result.indicators if details == "True" else [],
-        #    result.positions,
-        #    result.current_positions
-        #),
+        "result": (
+            result.indicators if details == "True" else [],
+            result.positions,
+            result.current_positions
+        ),
         "stats": {
             "drawdown": get_drawdowns_stats(result),
             "positions": get_position_stats(result)

--- a/api/stats/positions.py
+++ b/api/stats/positions.py
@@ -3,10 +3,10 @@ from collections import defaultdict
 
 def get_position_stats(positions):
     result_stats = {
-        'lowest_ratio': float('inf'),
+        'lowest_ratio': 0,
         'lowest_ratio_buy_index': 0,
         'lowest_ratio_sell_index': 0,
-        'biggest_ratio': float('-inf'),
+        'biggest_ratio': 0,
         'biggest_ratio_buy_index': 0,
         'biggest_ratio_sell_index': 0,
         'average_ratio': 1,
@@ -19,9 +19,9 @@ def get_position_stats(positions):
         'yearly_ratio': {}, 
         'max_open_positions_period': ('', '', 0),  # ('start_date', 'end_date', max_open_positions)
         'biggest_position_duration': 0,
-        'lowest_position_duration': float('inf'),
-        'lowest_cr_ratio': float('inf'),
-        'lowest_cr_ratio_details': []  # Add this line to store the details
+        'lowest_position_duration': 0,
+        'lowest_cr_ratio': 0,
+        'lowest_cr_ratio_details': []
     }
 
     if not positions.positions:
@@ -46,12 +46,12 @@ def get_position_stats(positions):
         cumulative_ratios.append(cumulative_ratios[-1] * ratio if cumulative_ratios else ratio)
         total_days += duration
 
-        if ratio < result_stats['lowest_ratio']:
+        if ratio < result_stats['lowest_ratio'] or result_stats['lowest_ratio'] == 0:
             result_stats['lowest_ratio'], result_stats['lowest_ratio_buy_index'], result_stats['lowest_ratio_sell_index'] = ratio, buy_index, sell_index
         if ratio > result_stats['biggest_ratio']:
             result_stats['biggest_ratio'], result_stats['biggest_ratio_buy_index'], result_stats['biggest_ratio_sell_index'] = ratio, buy_index, sell_index
 
-        if duration < result_stats['lowest_position_duration']:
+        if duration < result_stats['lowest_position_duration'] or result_stats['lowest_position_duration'] == 0:
             result_stats['lowest_position_duration'] = duration
         if duration > result_stats['biggest_position_duration']:
             result_stats['biggest_position_duration'] = duration
@@ -96,13 +96,13 @@ def get_position_stats(positions):
     for year in result_stats['yearly_ratio']:
         result_stats['yearly_ratio'][year] = round(result_stats['yearly_ratio'][year], 3)
 
-    min_cr_ratio = float('inf')
+    min_cr_ratio = 0
     current_cr_ratio = 1
-    cr_ratio_details = []  # Add this line to store the details
+    cr_ratio_details = []
     for ratio in result_stats['all_ratios']:
         current_cr_ratio *= ratio
-        cr_ratio_details.append(current_cr_ratio)  # Add this line to store the details
-        if current_cr_ratio < min_cr_ratio:
+        cr_ratio_details.append(current_cr_ratio)
+        if current_cr_ratio < min_cr_ratio or min_cr_ratio == 0:
             min_cr_ratio = current_cr_ratio
         if current_cr_ratio > 1:
             current_cr_ratio = 1
@@ -119,7 +119,7 @@ def get_position_stats(positions):
                                       max_open_period_end.strftime('%Y-%m-%d %H:%M:%S') if max_open_period_end else '',
                                       max_open_positions),
         'lowest_cr_ratio': min_cr_ratio,
-        'lowest_cr_ratio_details': cr_ratio_details  # Add this line to include the details in the result
+        'lowest_cr_ratio_details': cr_ratio_details
     })
 
     return result_stats


### PR DESCRIPTION
* [`api/stats/positions.py`](diffhunk://#diff-56ba3c7dc84c228a0af3398d7b3cccebd33ae432b6f5696a9ef4c54a42cd17c9L6-R9): Changed the initial values of `lowest_ratio`, `biggest_ratio`, `lowest_position_duration`, and `lowest_cr_ratio` from `float('inf')` and `float('-inf')` to `0`. [[1]](diffhunk://#diff-56ba3c7dc84c228a0af3398d7b3cccebd33ae432b6f5696a9ef4c54a42cd17c9L6-R9) [[2]](diffhunk://#diff-56ba3c7dc84c228a0af3398d7b3cccebd33ae432b6f5696a9ef4c54a42cd17c9L22-R24)
* [`api/stats/positions.py`](diffhunk://#diff-56ba3c7dc84c228a0af3398d7b3cccebd33ae432b6f5696a9ef4c54a42cd17c9L49-R54): Updated the conditions in the logic to correctly handle the new initial values of `lowest_ratio` and `lowest_position_duration`.
* [`api/stats/positions.py`](diffhunk://#diff-56ba3c7dc84c228a0af3398d7b3cccebd33ae432b6f5696a9ef4c54a42cd17c9L99-R105): Changed the initial value of `min_cr_ratio` from `float('inf')` to `0` and updated the logic to handle this change.
* [`api/stats/positions.py`](diffhunk://#diff-56ba3c7dc84c228a0af3398d7b3cccebd33ae432b6f5696a9ef4c54a42cd17c9L22-R24): Removed comments indicating the addition of details storage lines and included them directly in the code. [[1]](diffhunk://#diff-56ba3c7dc84c228a0af3398d7b3cccebd33ae432b6f5696a9ef4c54a42cd17c9L22-R24) [[2]](diffhunk://#diff-56ba3c7dc84c228a0af3398d7b3cccebd33ae432b6f5696a9ef4c54a42cd17c9L99-R105) [[3]](diffhunk://#diff-56ba3c7dc84c228a0af3398d7b3cccebd33ae432b6f5696a9ef4c54a42cd17c9L122-R122)